### PR TITLE
sepolicy: give radio access to tap2wake node

### DIFF
--- a/init.g2.rc
+++ b/init.g2.rc
@@ -281,7 +281,7 @@ on post-fs-data
     chown system camera /sys/class/leds/led:flash_torch/brightness
     chmod 0640 /sys/class/leds/led:flash_torch/brightness
 
-    chown system system /sys/devices/virtual/input/lge_touch/touch_gesture
+    chown system radio /sys/devices/virtual/input/lge_touch/touch_gesture
     write /sys/devices/virtual/input/lge_touch/touch_gesture 1
     chown root system /sys/devices/platform/tspdrv/nforce_timed
     chown root system /sys/devices/platform/kcal_ctrl.0/kcal

--- a/sepolicy/radio.te
+++ b/sepolicy/radio.te
@@ -1,0 +1,1 @@
+allow radio lge_touch_sysfs:file rw_file_perms;


### PR DESCRIPTION
* This is needed so telephony can disable tap2wake while
  the screen is off in-call.

Change-Id: Ibf62967f635233954e24040435eceae8a3d953ef