### PR TITLE
nfc: Remove hce access as it never worked and now causes linker errors f...

### DIFF
--- a/g2.mk
+++ b/g2.mk
@@ -108,7 +108,6 @@ PRODUCT_COPY_FILES += \
     $(NFCEE_ACCESS_PATH):system/etc/nfcee_access.xml \
     frameworks/native/data/etc/com.android.nfc_extras.xml:system/etc/permissions/com.android.nfc_extras.xml \
     frameworks/native/data/etc/android.hardware.nfc.xml:system/etc/permissions/android.hardware.nfc.xml \
-    frameworks/native/data/etc/android.hardware.nfc.hce.xml:system/etc/permissions/android.hardware.nfc.hce.xml
 
 PRODUCT_PROPERTY_OVERRIDES += \
         ro.sf.lcd_density=480 \


### PR DESCRIPTION
...or nxp devices

Change-Id: I3d8e09baefac2b3ca65bf1a30142bc21c91627b9